### PR TITLE
Remove GTM from E7Calc

### DIFF
--- a/docs/br/effectiveness.html
+++ b/docs/br/effectiveness.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="pt">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="epic seven damage calculator, epic 7 damage calculator, e7 damage calculator">
         <meta name="description" content="Damage Calculator for Epic Seven for every hero in the game. Enter your hero stats to get their damage potential.">

--- a/docs/br/ehp-calculator.html
+++ b/docs/br/ehp-calculator.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="pt">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="epic seven damage calculator, epic 7 damage calculator, e7 damage calculator">
         <meta name="description" content="Damage Calculator for Epic Seven for every hero in the game. Enter your hero stats to get their damage potential.">

--- a/docs/br/index.html
+++ b/docs/br/index.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="pt">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="epic seven damage calculator, epic 7 damage calculator, e7 damage calculator">
         <meta name="description" content="Damage Calculator for Epic Seven for every hero in the game. Enter your hero stats to get their damage potential.">

--- a/docs/br/speed-tuner.html
+++ b/docs/br/speed-tuner.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="pt">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="epic seven damage calculator, epic 7 damage calculator, e7 damage calculator, epic seven speed tuner, epic 7 speed tuner, e7 speed tuner">
         <meta name="description" content="Damage Calculator for Epic Seven for every hero in the game. Enter your hero stats to get their damage potential.">

--- a/docs/damage-calculator/calculator.js
+++ b/docs/damage-calculator/calculator.js
@@ -175,11 +175,6 @@ const manageSetForms = () => {
 
 /* eslint-disable no-unused-vars */
 const torrentSetToggled = () => {
-  window.dataLayer.push({
-    'event': 'toggle_torrent_set',
-    'torrent_set': torrentSetInput.checked ? 'on' : 'off'
-  });
-
   // reset value when toggling torrent set off
   if (!torrentSetInput.checked) {
     torrentSetStackInput.value = formDefaults.torrentSetStack;
@@ -805,11 +800,6 @@ const toggleChart = () => {
   chartButton = document.getElementById('chart-button-text');
 
   if (chartContainer.style.display == 'none') {
-    window.dataLayer.push({
-      'event': 'show_chart',
-      'hero': inputValues['hero'],
-      'lang': lang
-    });
     updateGraphSkillSelect();
     // This one doesn't really need to be debounced because it doesn't cause any visible lag if you toggle it a lot
     calculateChart(inputValues);

--- a/docs/damage-calculator/compare.js
+++ b/docs/damage-calculator/compare.js
@@ -42,10 +42,6 @@ const addToComparePool = () => {
   heroSets[document.getElementById('damage-mem-name').value] = dmg;
   allSets[hero.id] = heroSets;
   localStorage.setItem('heroes', JSON.stringify(allSets));
-  window.dataLayer.push({
-    'event': 'save_hero',
-    'hero': hero.id
-  });
   refreshCompareBadge();
 };
 
@@ -102,10 +98,6 @@ const compare = (heroId) => {
   unhideModalBody();
   document.getElementById('compare-splash').style.display = 'none';
   document.getElementById('damage-comparison-block').style.display = 'block';
-  window.dataLayer.push({
-    'event': 'compare_hero',
-    'hero': heroId
-  });
 };
 
 const clearCompare = (heroId) => {

--- a/docs/effectiveness/effectiveness.html
+++ b/docs/effectiveness/effectiveness.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="en">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="ark recode damage calculator, ark re:code damage calculator, ark re codes damage calculator">
         <meta name="description" content="Damage Calculator for Ark Re:Code for every hero in the game. Enter your hero stats to get their damage potential.">

--- a/docs/ehp-calculator/ehp-calculator.html
+++ b/docs/ehp-calculator/ehp-calculator.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="en">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="ark recode damage calculator, ark re:code damage calculator, ark re codes damage calculator">
         <meta name="description" content="Damage Calculator for Ark Re:Code for every hero in the game. Enter your hero stats to get their damage potential.">

--- a/docs/form.js
+++ b/docs/form.js
@@ -1392,11 +1392,6 @@ buildInitialForm = () => {
         if (!loadingQueryParams) {
           deleteParams(heroes[currentHero.id].form?.map(element => element.id));
         }
-
-        window.dataLayer.push({
-          'event': 'select_hero',
-          'hero': hero.name
-        });
         refreshCompareBadge();
   
         $(chartSkillSelector).find('option').remove();
@@ -1431,10 +1426,6 @@ buildInitialForm = () => {
           update(elements.target_max_hp.id);
         }
         oneshotInput.value = selected.dataset.hp;
-        window.dataLayer.push({
-          'event': 'select_preset_def',
-          'def_unit': selected.value
-        });
       } else {
         // To ensure caides damage reduction is removed when switching to manual
         resolve();
@@ -1458,10 +1449,6 @@ buildInitialForm = () => {
           update('def-pc-up');
         
         }
-        window.dataLayer.push({
-          'event': 'select_preset_dmg_red',
-          'dmg_red': selected.value
-        });
       }
     };
 
@@ -1486,11 +1473,6 @@ buildInitialForm = () => {
       dedupeForm(hero, artifact);
       buildArtifact(artifact);
       resolve();
-      window.dataLayer.push({
-        'event': 'select_artifact',
-        'artifact': artifact.name,
-        'hero': heroes[heroSelector.value]?.name || 'None'
-      });
     };
 
     const hero = heroes[heroSelector.value];
@@ -1542,10 +1524,6 @@ function applyTheme() {
     initTheme();
     darkSwitch.addEventListener('change', () => {
       applyTheme();
-      window.dataLayer.push({
-        'event': 'toggle_dark_mode',
-        'dark_mode': darkSwitch.checked ? 'on' : 'off'
-      });
     });
   }
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="en">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="ark recode damage calculator, ark re:code damage calculator, ark re codes damage calculator">
         <meta name="description" content="Damage Calculator for Ark Re:Code for every hero in the game. Enter your hero stats to get their damage potential.">

--- a/docs/jp/effectiveness.html
+++ b/docs/jp/effectiveness.html
@@ -2,19 +2,6 @@
 <!DOCTYPE html>
 <html id="root" lang="jp">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="エピックセブン　ダメージ　計算機, エピなな　ダメージ 計算機, Epic Seven ダメージ 計算機">
         <meta name="description" content="エピックセブン用ダメージ計算機。英雄のステータスを入力してスキルダメージの計算を行います。">

--- a/docs/jp/index.html
+++ b/docs/jp/index.html
@@ -2,19 +2,6 @@
 <!DOCTYPE html>
 <html id="root" lang="jp">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="エピックセブン　ダメージ　計算機, エピなな　ダメージ 計算機, Epic Seven ダメージ 計算機">
         <meta name="description" content="エピックセブン用ダメージ計算機。英雄のステータスを入力してスキルダメージの計算を行います。">

--- a/docs/kr/effectiveness.html
+++ b/docs/kr/effectiveness.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="kr">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="에픽세븐 데미지 계산기">
         <meta name="description" content="에픽세븐 영웅들의 데미지 계산기 입니다. 본인 영웅의 스텟을 입력해 데미지를 알아보세요.">

--- a/docs/kr/index.html
+++ b/docs/kr/index.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="kr">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="에픽세븐 데미지 계산기">
         <meta name="description" content="에픽세븐 영웅들의 데미지 계산기 입니다. 본인 영웅의 스텟을 입력해 데미지를 알아보세요.">

--- a/docs/ldplayer.html
+++ b/docs/ldplayer.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="epic seven damage calculator, epic 7 damage calculator, e7 damage calculator">
         <meta name="description" content="Damage Calculator for Epic Seven for every hero in the game. Enter your hero stats to get their damage potential.">

--- a/docs/query-params.js
+++ b/docs/query-params.js
@@ -283,16 +283,6 @@ const loadQueryParams = async () => {
         }
       }
     }
-        
-    // push event to dataLayer
-    const queryString = queryParams.toString();
-    if (queryString.length) {
-      window.dataLayer.push({
-        'event': 'loaded_query_params',
-        'page': page,
-        'loaded_params': queryString
-      });
-    }
   } catch (error) {  // probably only going to reach here on some ancient browser that won't load the site properly anyway
     console.log(`Could not load queryParams: ${error}`);
   }
@@ -485,10 +475,4 @@ const copyLinkToClipboard = () => {
       shareButton.innerText = i18n[lang].form.link_copied || 'Link Copied!';
     }
   }
-
-  window.dataLayer.push({
-    'event': 'shared_query_params',
-    'page': page,
-    'shared_params': linkURL.search
-  });
 };

--- a/docs/speed-tuner/speed-tuner.html
+++ b/docs/speed-tuner/speed-tuner.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="en">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="ark recode damage calculator, ark re code damage calculator, ark re:code calculator, ark recode speed tuner, ark re code speed tuner, ark re:code speed tuner">
         <meta name="description" content="Damage Calculator for Ark Re:Code for every hero in the game. Enter your hero stats to get their damage potential.">

--- a/docs/speed-tuner/speed-tuner.js
+++ b/docs/speed-tuner/speed-tuner.js
@@ -100,17 +100,9 @@ numberParams = ['slowerSpeed', 'slowerPush', 'fasterSpeed', 'fasterPush', 'faste
 page = 'speed_tuner';
 
 fasterPushesToggled = () => {
-  window.dataLayer.push({
-    'event': 'toggle_faster_pushes',
-    'faster_pushes': fasterPushesSlowerInput.checked ? 'on' : 'off'
-  });
 };
 
 stigmaPolitisToggled = () => {
-  window.dataLayer.push({
-    'event': 'toggle_stigma_politis',
-    'stigma_politis': stigmaPolitisInput.checked ? 'on' : 'off'
-  });
 };
 
 // style output text and outlines

--- a/docs/zh/effectiveness.html
+++ b/docs/zh/effectiveness.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="zhCN">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="第七史诗 伤害计算器, 第七史诗 伤害模拟器">
         <meta name="description" content="填入第七史诗的角色面板数据, 模拟实际战斗伤害">

--- a/docs/zh/index.html
+++ b/docs/zh/index.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="zhCN">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="第七史诗 伤害计算器, 第七史诗 伤害模拟器">
         <meta name="description" content="填入第七史诗的角色面板数据, 模拟实际战斗伤害">

--- a/docs/zhTW/effectiveness.html
+++ b/docs/zhTW/effectiveness.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="zhTW">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="第七史詩 傷害計算器, 第七史詩 傷害模擬器">
         <meta name="description" content="填入第七史詩的角色面板數據, 模擬實際戰鬥傷害">

--- a/docs/zhTW/index.html
+++ b/docs/zhTW/index.html
@@ -1,19 +1,6 @@
 <!DOCTYPE html>
 <html id="root" lang="zhTW">
     <head>
-        <script>
-            (function(window, document, script, layer, ident) {
-                window[layer] = window[layer] || [];
-                window[layer].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-                var f = document.getElementsByTagName(script)[0],
-                j = document.createElement(script),
-                dataLayer = layer != 'dataLayer' ? '&l=' + layer : '';
-                j.async=true;
-                j.src= 'https://www.googletagmanager.com/gtm.js?id=' + ident + dataLayer;
-                f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-M7H68RW');
-        </script>
-
         <meta charset="utf-8">
         <meta name="keywords" content="第七史詩 傷害計算器, 第七史詩 傷害模擬器">
         <meta name="description" content="填入第七史詩的角色面板數據, 模擬實際戰鬥傷害">


### PR DESCRIPTION
Hey, just noticed some events from this Ark:Recode damage calc showing up in the Google Analytics dashboard for E7Calc, would you mind removing the GTM code if you're not planning to use Google Analytics or update the tag to your own if you do want to use it?  Thanks!

In this MR I assumed you're not planning to utilize Google Analytics so you should be able to just merge this one in.

Also, I liked your idea of adding in the character and artifact portraits so I did something similar on the E7 Calc too :P